### PR TITLE
Add TestEvaluator helper module

### DIFF
--- a/test/support/test_evaluator.ex
+++ b/test/support/test_evaluator.ex
@@ -1,0 +1,51 @@
+defmodule TestEvaluator do
+  alias Fika.ErlTranslate
+
+  def eval(code, bindings \\ [])
+
+  # Evaluates a string representing an expression.
+  #
+  # Usage examples:
+  #   1) test "add has less precedence than mult" do
+  #        {7, _} = eval("1 + a * 3", [{:a, 2}])
+  #      end
+  #
+  #   2) test "match operator" do
+  #        {5, [a: 5]} = eval("a = 5", [])
+  #      end
+  def eval(str_exp, bindings) when is_binary(str_exp) do
+    case TestParser.expression(str_exp) do
+      {:ok, [parsed], _, _, _, _} ->
+        {:value, evaluated, new_bindings} =
+          parsed
+          |> ErlTranslate.translate_expression()
+          |> :erl_eval.expr(bindings)
+
+        {evaluated, new_bindings}
+
+      err ->
+        err
+    end
+  end
+
+  # Evaluates a piece of AST representing an expression.
+  #
+  # Usage example:
+  #   test "erlang ast" do
+  #     exp_ast = {
+  #       :bin,
+  #       1,
+  #       [
+  #         {:bin_element, 1, {:string, 1, 'Hello'}, :default, :default},
+  #         {:bin_element, 1, {:string, 1, ' '}, :default, :default},
+  #         {:bin_element, 1, {:string, 1, 'World'}, :default, :default}
+  #       ]
+  #     }
+  #
+  #     {"Hello World", _} = eval(exp_ast)
+  #   end
+  def eval(ast_exp, bindings) when is_tuple(ast_exp) do
+    {:value, evaluated, new_bindings} = :erl_eval.expr(ast_exp, bindings)
+    {evaluated, new_bindings}
+  end
+end

--- a/test/support/test_evaluator.ex
+++ b/test/support/test_evaluator.ex
@@ -13,8 +13,8 @@ defmodule TestEvaluator do
   #   2) test "match operator" do
   #        {5, [a: 5]} = eval("a = 5")
   #      end
-  def eval(str_exp, bindings) when is_binary(str_exp) do
-    case TestParser.expression(str_exp) do
+  def eval(str, bindings) when is_binary(str) do
+    case TestParser.expression(str) do
       {:ok, [parsed], _, _, _, _} ->
         parsed
         |> ErlTranslate.translate_expression()
@@ -41,8 +41,8 @@ defmodule TestEvaluator do
   #
   #     {"Hello World", _} = eval(exp_ast)
   #   end
-  def eval(ast_exp, bindings) when is_tuple(ast_exp) do
-    {:value, evaluated, new_bindings} = :erl_eval.expr(ast_exp, bindings)
+  def eval(ast, bindings) when is_tuple(ast) do
+    {:value, evaluated, new_bindings} = :erl_eval.expr(ast, bindings)
     {evaluated, new_bindings}
   end
 end

--- a/test/support/test_evaluator.ex
+++ b/test/support/test_evaluator.ex
@@ -75,8 +75,9 @@ defmodule TestEvaluator do
         end
       end)
 
-    with {:ok, env} <- env_from_bindings do
-      TypeChecker.infer_exp(env, ast)
+    case env_from_bindings do
+      {:ok, env} -> TypeChecker.infer_exp(env, ast)
+      error -> error
     end
   end
 end

--- a/test/support/test_evaluator.ex
+++ b/test/support/test_evaluator.ex
@@ -15,7 +15,7 @@ defmodule TestEvaluator do
   #   2) test "match operator" do
   #        {5, [a: 5]} = eval("a = 5")
   #      end
-  def eval(str, bindings \\ []) when is_binary(str) do
+  def eval(str, bindings \\ []) do
     {:value, evaluated, new_bindings} =
       TestParser.expression!(str)
       |> check_types(bindings)

--- a/test/support/test_evaluator.ex
+++ b/test/support/test_evaluator.ex
@@ -11,17 +11,14 @@ defmodule TestEvaluator do
   #      end
   #
   #   2) test "match operator" do
-  #        {5, [a: 5]} = eval("a = 5", [])
+  #        {5, [a: 5]} = eval("a = 5")
   #      end
   def eval(str_exp, bindings) when is_binary(str_exp) do
     case TestParser.expression(str_exp) do
       {:ok, [parsed], _, _, _, _} ->
-        {:value, evaluated, new_bindings} =
-          parsed
-          |> ErlTranslate.translate_expression()
-          |> :erl_eval.expr(bindings)
-
-        {evaluated, new_bindings}
+        parsed
+        |> ErlTranslate.translate_expression()
+        |> eval(bindings)
 
       err ->
         err


### PR DESCRIPTION
This PR introduces `TestEvaluator` test helper, which will be needed to properly test operators precedence (as discussed on Discord). Some usage examples can be seen in the documentation I inserted in the code itself.